### PR TITLE
Avoid global variables and init functions

### DIFF
--- a/client.go
+++ b/client.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
+	"os"
 	"path"
 )
 
@@ -19,6 +20,20 @@ type ClientConfig struct {
 
 // NewClientConfig constructs a ClientConfig object with the environment variables set as default
 func NewClientConfig() ClientConfig {
+	apiHost := "https://api.hubapi.com"
+	var apiKey string
+	var oauthToken string
+
+	if os.Getenv("HUBSPOT_API_HOST") != "" {
+		apiHost = os.Getenv("HUBSPOT_API_HOST")
+	}
+	if os.Getenv("HUBSPOT_API_KEY") != "" {
+		apiKey = os.Getenv("HUBSPOT_API_KEY")
+	}
+	if os.Getenv("HUBSPOT_OAUTH_TOKEN") != "" {
+		oauthToken = os.Getenv("HUBSPOT_OAUTH_TOKEN")
+	}
+
 	return ClientConfig{
 		APIHost:    apiHost,
 		APIKey:     apiKey,

--- a/hubspot.go
+++ b/hubspot.go
@@ -76,27 +76,6 @@ Manual/eventual configuration can be set by creating a configuration object dire
 */
 package hubspot
 
-import "os"
-
-var (
-	apiHost    = "https://api.hubapi.com"
-	apiKey     string
-	oauthToken string
-)
-
-func init() {
-	// Set environment variables configuration.
-	if os.Getenv("HUBSPOT_API_HOST") != "" {
-		apiHost = os.Getenv("HUBSPOT_API_HOST")
-	}
-	if os.Getenv("HUBSPOT_API_KEY") != "" {
-		apiKey = os.Getenv("HUBSPOT_API_KEY")
-	}
-	if os.Getenv("HUBSPOT_OAUTH_TOKEN") != "" {
-		oauthToken = os.Getenv("HUBSPOT_OAUTH_TOKEN")
-	}
-}
-
 // ErrorResponse object
 type ErrorResponse struct {
 	Status  string `json:"status,omitempty"`


### PR DESCRIPTION
Fixes #1 

This PR removed the `init()` function and global variables from the library, but
does not change the API or any usage.

One caveat is that multiple calls to `NewClientConfig` will re-read the
environment variables on each call. However, this can be mitigated by the user
of the library by reading the config values and instantiating their own
`ClientConfig` instance then supplying that instance to create new clients.

```go
cachedConfig := hubspot.NewClentConfig()
firstClient := hubspot.NewClient(cachedConfig)
secondClient := hubspot.NewClient(cachedConfig)
```